### PR TITLE
Add send-messag

### DIFF
--- a/pybr2021/bot.py
+++ b/pybr2021/bot.py
@@ -22,7 +22,7 @@ if SENTRY_TOKEN:
 DISCORD_TOKEN = config("DISCORD_TOKEN")
 
 bot = commands.Bot(command_prefix="pybr!", intents=discord.Intents.all())
-#bot.add_cog(cogs.Reminders(bot))
+bot.add_cog(cogs.Reminders(bot))
 bot.add_cog(cogs.Greetings(bot))
 
 config_file = toml.load("./config.toml")


### PR DESCRIPTION
Adicionado o comando 
`pybr!send-message #canal mensagem ...`

Para permitir que o bot gere mensagens no evento (principlamente em canais de aviso)