### PR TITLE
Mudando log para ver o id do canal

### DIFF
--- a/pybr2021/cogs/greetings.py
+++ b/pybr2021/cogs/greetings.py
@@ -371,7 +371,7 @@ class Greetings(commands.Cog):
         role = await self.get_attendee_role(message.guild)
         await member.add_roles(role)
         await message.channel.delete()
-        await logchannel(self.bot, f"Inscrição confirmada, participante {member.mention}. Canal <#{member.id}>")
+        await logchannel(self.bot, f"Inscrição confirmada, participante {member.mention}. Canal {member.id}")
         logger.info(
             f"User authenticated and channel deleted. user={message.author.name}, id={message.author.id}"
         )


### PR DESCRIPTION
Para fazer com que a mensagem:
`Inscrição confirmada, participante @rodrighos. Canal #deleted-channel`
Mude para 
`Inscrição confirmada, participante @rodrighos. Canal 999999999999`

Isso torna o log pesquisavel pelo id da pessoa e validar se o canal for excluido